### PR TITLE
fix(popup): remove popup before showing previous

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -402,6 +402,8 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
         if (index !== -1) {
           popupStack.splice(index, 1);
         }
+        
+        popup.remove();
 
         if (popupStack.length > 0) {
           popupStack[popupStack.length - 1].show();
@@ -417,8 +419,6 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
           }, 400, false);
           ($ionicPopup._backButtonActionDone || noop)();
         }
-
-        popup.remove();
 
         return result;
       });


### PR DESCRIPTION
Make sure to close and remove the currently shown popup before showing the previous one. It closes #4061.

The following code reproduces the problem:

``` js
$timeout(function() {
    $ionicPopup.alert({
        title: "Popup 2",
    });
}, 1000);

$ionicPopup.alert({
    title: "Popup 1"
});
```
